### PR TITLE
update the zero_to_hero_guide llama stack version to 0.1.0

### DIFF
--- a/docs/zero_to_hero_guide/README.md
+++ b/docs/zero_to_hero_guide/README.md
@@ -73,7 +73,7 @@ If you're looking for more specific topics, we have a [Zero to Hero Guide](#next
    Open a new terminal and install `llama-stack`:
    ```bash
    conda activate ollama
-   pip install llama-stack==0.0.61
+   pip install llama-stack==0.1.0
    ```
 
 ---


### PR DESCRIPTION
# What does this PR do?

The Zero to Hero guide currently references an older `0.0.61` llama-stack version. Using the most recent stable release of the product in the documentation, would help the users not to go through any issues from the older llama-stack versions.


## Test Plan

I have ran the workflow locally using the proposed version change and I am able to proceed further ahead without any issue.


## Sources

Please link relevant resources if necessary.


## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Ran pre-commit to handle lint / formatting issues.
- [ ] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
